### PR TITLE
Replace 'or' with '||' and use QT's PKGCONFIG macro

### DIFF
--- a/itchio.pro
+++ b/itchio.pro
@@ -33,7 +33,8 @@ FORMS    += gameswindow.ui \
 RESOURCES += \
     resources.qrc
 
-LIBS += `pkg-config --libs openssl`
+CONFIG += link_pkgconfig
+PKGCONFIG += openssl
 
 DISTFILES += \
     stylesheet.qss

--- a/logindialog.cpp
+++ b/logindialog.cpp
@@ -32,7 +32,7 @@ void LoginDialog::on_loginButton_clicked()
 {
     QString username = ui->usernameInput->text();
     QString password =  ui->passwordInput->text();
-    if (username == "" or password == "") {
+    if (username == "" || password == "") {
         setStatus("Please enter username and password", false);
         return;
     }


### PR DESCRIPTION
Building on Windows, I could only get pkg-config to work by using qmake's [PKGCONFIG variable](http://qt-project.org/faq/answer/does_qmake_have_support_for_pkg-config).

The alternative and/or/etc. tokens in C++ are obscure and require certain flags or header files in at least one compiler.
