### PR TITLE
Removed hard link to OpenSSL in windows.

### DIFF
--- a/itchio.pro
+++ b/itchio.pro
@@ -56,7 +56,4 @@ RESOURCES += \
 
 CONFIG += link_pkgconfig
 
-unix:PKGCONFIG += openssl
-
-win32:LIBS += -LC:/OpenSSL-Win32/lib -lubsec
-win32:INCLUDEPATH += C:/OpenSSL-Win32/include
+PKGCONFIG += openssl


### PR DESCRIPTION
For the setup, see issue #14.
