### PR TITLE
AppController now inherits from QApplication

### DIFF
--- a/appcontroller.h
+++ b/appcontroller.h
@@ -5,6 +5,7 @@
 #include <QSystemTrayIcon>
 #include <QMenu>
 #include <QAction>
+#include <QApplication>
 
 #include "itchioapi.h"
 #include "traynotifications.h"
@@ -13,16 +14,15 @@
 class AppWindow;
 class SecondaryWindow;
 
-class AppController : public QObject
+class AppController : public QApplication
 {
     Q_OBJECT
 
 public:
-    explicit AppController(QObject* const parent = 0);
+    AppController(int& argc, char** argv);
 
-    ItchioApi* api;
-
-    AppSettings* settings;
+    AppSettings settings;
+    ItchioApi api;
 
     void setupTrayIcon();
     void showTrayIconNotification(TrayNotifications notification, int duration);
@@ -30,8 +30,6 @@ public:
     void onLogin();
 
 private:
-    QString settingsFile;
-
     QAction* actionQuit;
     QAction* actionSettings;
 
@@ -39,19 +37,18 @@ private:
     SecondaryWindow* loginWindow;
     SecondaryWindow* settingsWindow;
 
-    QSystemTrayIcon* trayIcon;
+    QSystemTrayIcon trayIcon;
     QMenu* trayIconMenu;
 
     bool loginWithApiKey;
 
     void setupLogin();
-    void setupSettings();
     void onAutoLoginFailure(QString error);
 
+    static QString loadStyleSheet();
 signals:
 
 public slots:
-    void quit();
     void showSettings();
 
     void trayIconDoubleClick(QSystemTrayIcon::ActivationReason reason);

--- a/itchio.pro
+++ b/itchio.pro
@@ -31,7 +31,6 @@ SOURCES += main.cpp \
 
 HEADERS += itchioapi.h \
     traynotifications.h \
-    settings.h \
     appcontroller.h \
     appsettings.h \
     appwindow.h \

--- a/main.cpp
+++ b/main.cpp
@@ -1,26 +1,6 @@
-#include <QApplication>
-#include <QFile>
-
 #include "appcontroller.h"
 
 int main(int argc, char* argv[])
 {
-    QApplication a(argc, argv);
-
-    a.setOrganizationName("itch.io");
-    a.setOrganizationDomain("itch.io");
-    a.setApplicationName("itch.io");
-
-    QFile styleFile(":/stylesheet.qss");
-
-    if (styleFile.open(QIODevice::ReadOnly)) {
-        QTextStream textStream(&styleFile);
-        QString styleSheet = textStream.readAll();
-        styleFile.close();
-        a.setStyleSheet(styleSheet);
-    }
-
-    AppController controller;
-
-    return a.exec();
+    return AppController(argc, argv).exec();
 }

--- a/widgets/librarywidget.cpp
+++ b/widgets/librarywidget.cpp
@@ -12,7 +12,7 @@ LibraryWidget::LibraryWidget(QWidget* const parent, AppController* const control
 {
     ui->setupUi(this);
 
-    controller->api->myOwnedKeys([this](QList<DownloadKey> keys) {
+    controller->api.myOwnedKeys([this](QList<DownloadKey> keys) {
         onMyOwnedKeys(keys);
     });
 }

--- a/widgets/secondary/loginwidget.cpp
+++ b/widgets/secondary/loginwidget.cpp
@@ -35,7 +35,7 @@ void LoginWidget::onLoginTentative()
     }
 
     setStatus("Logging in...", true);
-    controller->api->loginWithPassword(username, password, [this](bool success, QString err) {
+    controller->api.loginWithPassword(username, password, [this](bool success, QString err) {
         if (success) {
             controller->onLogin();
         } else {

--- a/widgets/secondary/settingswidget.cpp
+++ b/widgets/secondary/settingswidget.cpp
@@ -26,22 +26,22 @@ SettingsWidget::~SettingsWidget()
 
 void SettingsWidget::refresh()
 {
-    keepLoggedInBox->setChecked(controller->settings->autoLogin());
-    automaticallyCheckForUpdatesBox->setChecked(controller->settings->autoUpdateChecks());
-    showTrayNotificationsBox->setChecked(controller->settings->showTrayNotifications());
+    keepLoggedInBox->setChecked(controller->settings.autoLogin());
+    automaticallyCheckForUpdatesBox->setChecked(controller->settings.autoUpdateChecks());
+    showTrayNotificationsBox->setChecked(controller->settings.showTrayNotifications());
 }
 
 void SettingsWidget::on_keepLoggedInBox_clicked()
 {
-    controller->settings->enableAutoLogin(keepLoggedInBox->isChecked());
+    controller->settings.enableAutoLogin(keepLoggedInBox->isChecked());
 }
 
 void SettingsWidget::on_automaticallyCheckForUpdatesBox_clicked()
 {
-    controller->settings->enableAutoUpdateChecks(automaticallyCheckForUpdatesBox->isChecked());
+    controller->settings.enableAutoUpdateChecks(automaticallyCheckForUpdatesBox->isChecked());
 }
 
 void SettingsWidget::on_showTrayNotificationsBox_clicked()
 {
-    controller->settings->enableTrayNotifications(showTrayNotificationsBox->isChecked());
+    controller->settings.enableTrayNotifications(showTrayNotificationsBox->isChecked());
 }


### PR DESCRIPTION
- Replaced a few dynamic allocations in favor of their automatic allocations.
- Added a fallback for QStandardPaths::AppDataLocation for systems that don't have access to Qt 5.4 yet.
